### PR TITLE
23 profile picture field improvements

### DIFF
--- a/opairo-app/package.json
+++ b/opairo-app/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@rpldy/upload-button": "^1.11.0",
+    "@rpldy/upload-preview": "^1.11.0",
+    "@rpldy/uploady": "^1.11.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",

--- a/opairo-app/src/components/profile/UpdateProfileForm.jsx
+++ b/opairo-app/src/components/profile/UpdateProfileForm.jsx
@@ -58,26 +58,6 @@ function UpdateProfileForm(props) {
 
     return (
         <Form id='account-edit-form' className='border p-4 rounded' noValidate validated={validated} onSubmit={handleSubmit}>
-            <Form.Group className='mb-3 d-flex flex-column'>
-                <Form.Label>Profile Picture</Form.Label>
-                <Image
-                    src={form.profile_picture}
-                    //src={profile_picture ? profile_picture : account.profile_picture}
-                    roundedCircle
-                    width={120}
-                    height={120}
-                    className='mb-3 border border-primary border-2 align-self-center'
-                />
-                <div className='justify-content-centre'>
-                    <Form.Control onChange={(e) => {setProfilePicture(e.target.files[0]);
-                        setForm({ ...form, profile_picture: URL.createObjectURL(e.target.files[0]) }); }
-                    } className='align-self-centre' type='file'/>
-                </div>
-                
-                <Form.Control.Feedback type='invalid'>
-                    Please select a profile picture.
-                </Form.Control.Feedback>
-            </Form.Group>
             <Form.Group className="mb-3">
                 <Form.Label>Account Name</Form.Label>
                 <Form.Control
@@ -105,6 +85,26 @@ function UpdateProfileForm(props) {
                 </Form.Text>
                 <Form.Control.Feedback type="invalid">
                     Please provide an account slug.
+                </Form.Control.Feedback>
+            </Form.Group>
+            <Form.Group className='mb-3 d-flex flex-column'>
+                <Form.Label>Profile Picture</Form.Label>
+                <Image
+                    src={form.profile_picture}
+                    //src={profile_picture ? profile_picture : account.profile_picture}
+                    roundedCircle
+                    width={120}
+                    height={120}
+                    className='mb-3 border border-primary border-2 align-self-center'
+                />
+                <div className='justify-content-centre'>
+                    <Form.Control onChange={(e) => {setProfilePicture(e.target.files[0]);
+                        setForm({ ...form, profile_picture: URL.createObjectURL(e.target.files[0]) }); }
+                    } className='align-self-centre' type='file'/>
+                </div>
+                
+                <Form.Control.Feedback type='invalid'>
+                    Please select a profile picture.
                 </Form.Control.Feedback>
             </Form.Group>
             <div className="text-content text-danger">{error && <p>{error}</p>}</div>

--- a/opairo-app/src/components/profile/UpdateProfileForm.jsx
+++ b/opairo-app/src/components/profile/UpdateProfileForm.jsx
@@ -99,16 +99,15 @@ function UpdateProfileForm(props) {
                 />
                 <div className='justify-content-centre'>
                     <Form.Control onChange={(e) => {setProfilePicture(e.target.files[0]);
-                        setForm({ ...form, profile_picture: URL.createObjectURL(e.target.files[0]) }); }
-                    } className='align-self-centre' type='file'/>
+                        setForm({ ...form, profile_picture: URL.createObjectURL(e.target.files[0]) }); }} 
+                        className='align-self-centre' type='file'/>
                 </div>
-                
                 <Form.Control.Feedback type='invalid'>
                     Please select a profile picture.
                 </Form.Control.Feedback>
             </Form.Group>
             <div className="text-content text-danger">{error && <p>{error}</p>}</div>
-            <div className="justify-content-end d-flex">
+            <div className="justify-content-center d-flex pt-4">
             <Button variant="primary" type="submit" style={{width: 150}}>
                 Save Changes
             </Button>

--- a/opairo-app/src/components/profile/UpdateProfileForm.jsx
+++ b/opairo-app/src/components/profile/UpdateProfileForm.jsx
@@ -29,9 +29,7 @@ function UpdateProfileForm(props) {
         const data = {
             account_name: form.account_name,
             account_slug: form.account_slug,
-            profile_picture: form.profile_picture,
         };
-
 
         const formData = new FormData();
 
@@ -61,15 +59,21 @@ function UpdateProfileForm(props) {
     return (
         <Form id='account-edit-form' className='border p-4 rounded' noValidate validated={validated} onSubmit={handleSubmit}>
             <Form.Group className='mb-3 d-flex flex-column'>
-                <Form.Label className='text-center'>Profile Picture</Form.Label>
+                <Form.Label>Profile Picture</Form.Label>
                 <Image
                     src={form.profile_picture}
+                    //src={profile_picture ? profile_picture : account.profile_picture}
                     roundedCircle
                     width={120}
                     height={120}
                     className='mb-3 border border-primary border-2 align-self-center'
                 />
-                <Form.Control onChange={(e) => setProfilePicture(e.target.files[0])} className='w-50 align-self-centre' type='file' size='sm'/>
+                <div className='justify-content-centre'>
+                    <Form.Control onChange={(e) => {setProfilePicture(e.target.files[0]);
+                        setForm({ ...form, profile_picture: URL.createObjectURL(e.target.files[0]) }); }
+                    } className='align-self-centre' type='file'/>
+                </div>
+                
                 <Form.Control.Feedback type='invalid'>
                     Please select a profile picture.
                 </Form.Control.Feedback>

--- a/opairo-app/src/components/profile/UpdateProfileForm.jsx
+++ b/opairo-app/src/components/profile/UpdateProfileForm.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from 'react';
+import React, { useState } from 'react';
 import { Button, Form, Image } from 'react-bootstrap';
 import { useNavigate } from 'react-router-dom';
 


### PR DESCRIPTION
- Removed form.profile_picture from data dict in handleSubmit to prevent validation errors when the user doesn't change the form (this doesn't occur on other fields as they are filled in on load, but file upload can't do this).
- Updated Form.Control for image upload to update  form.profile_picture so image is seen by user before upload occurs.
- Removed useContext from form to remove a warning.
- Changed form order so profile_picture is below account)name as this is less important and optional.
- Added more space above save/cancel buttons to prevent misclicks due to proximity to upload picture button.

Closes #23 
